### PR TITLE
add build inputs to dev shell

### DIFF
--- a/gen.nix
+++ b/gen.nix
@@ -35,7 +35,7 @@ in {
   };
   devShells.default = pkgs.mkShell {
     name = "${name}-env";
-    buildInputs = [ haskell-env ];
+    buildInputs = [ haskell-env ] ++ websiteBuildInputs;
 
     shellHook = ''
       export HAKYLL_ENV="development"


### PR DESCRIPTION
currently, if a user of this flake runs `nix run . -- watch` (or another `nix run` command), it will not use `websiteBuildInputs` like `nix build .#website` does. this can lead to **the watch feature not working** if any provided build inputs are required by the generated hakyll executable to build the site (*example*: a hakyll compiler that depends on [unix filters](https://jaspervdj.be/hakyll/reference/Hakyll-Core-UnixFilter.html)).

this PR simply adds the build inputs to the dev shell environment, which can then be used by the `nix run` executable.

---

**P.S.** thanks for the flake; it is quite helpful!