### PR TITLE
fix: add missing system argument

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,38 +23,30 @@
   }:
     let
       # taken from nixpkgs flake.nix
-      systems = [
-        "x86_64-linux"
-        "i686-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "armv6l-linux"
-        "armv7l-linux"
-      ];
-
-      # taken from nixpkgs flake.nix
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-
-      overlay = (self: super: {
-        haskellPackages = super.haskellPackages.extend (hsSelf: hsSuper: {
-          # hakyll = hsSuper.callCabal2nix "hakyll" "${hakyll-src}" { };
-          # hakyll-sass = hsSuper.callCabal2nix "hakyll-sass" "${hakyll-sass-src}" { };
-        });
-      });
-
-      overlays = [ overlay ];
-
-      # this is just nixpkgs.legacyPackages but with an overlay
-      pkgs = forAllSystems (system: import nixpkgs { inherit system overlays; });
+      forAllSystems = f: nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (system: f system);
     in
-      {
-        inherit pkgs overlay overlays;
-        lib = rec {
-          mkBuilderPackage = args: (mkAllOutputs args).packages.builder;
-          mkWebsitePackage = args: (mkAllOutputs args).packages.website;
-          mkDevShell       = args: (mkAllOutputs args).devShell;
-          mkApp            = args: (mkAllOutputs args).defaultApp;
-          mkAllOutputs = import ./gen.nix pkgs.${system};
-        };
-      };
+      forAllSystems (system: 
+        let
+          overlay = (self: super: {
+            haskellPackages = super.haskellPackages.extend (hsSelf: hsSuper: {
+              # hakyll = hsSuper.callCabal2nix "hakyll" "${hakyll-src}" { };
+              # hakyll-sass = hsSuper.callCabal2nix "hakyll-sass" "${hakyll-sass-src}" { };
+            });
+          });
+
+          overlays = [ overlay ];
+
+          # this is just nixpkgs.legacyPackages but with an overlay
+          pkgs = import nixpkgs { inherit system overlays; };
+        in
+          {
+            inherit pkgs overlay overlays;
+            lib = rec {
+              mkBuilderPackage = args: (mkAllOutputs args).packages.builder;
+              mkWebsitePackage = args: (mkAllOutputs args).packages.website;
+              mkDevShell       = args: (mkAllOutputs args).devShell;
+              mkApp            = args: (mkAllOutputs args).defaultApp;
+              mkAllOutputs = import ./gen.nix pkgs;
+            };
+          });
 }

--- a/readme.md
+++ b/readme.md
@@ -4,12 +4,11 @@ Use this to easily build your hakyll websites using nix flakes.
 
 `hakyll-flakes.lib.mk*` takes in a set with the following fields:
 
-- `system`: the system to build for.
 - `name`: the name of website. this must also be the name of the haskell project and executable generated.
 - `src`: the source directory (usually `./.`), which must contain at a minimum your `package.yaml` or `project-name.cabal` file.
 - `websiteBuildInputs` (optional): any runtime inputs the builder needs to build the website.
 
-`hakyll-flakes.overlay` is the overlay that `hakyll-flakes` uses internally to get hakyll working (this will not work on an arbitrary version of nixpkgs), and `hakyll-flake.pkgs` is the legacyPackages that `hakyll-flakes` uses internally (this should always work). If you want to use one consistent nixpkgs set, you can set `websiteBuildInputs = with hakyll-flakes.pkgs.${system}; [ ... ]`. Alternatively, you can use your own nixpkgs set for these inputs, there's no reason they need to be the same.
+`hakyll-flakes.overlay` is the overlay that `hakyll-flakes` uses internally to get hakyll working (this will not work on an arbitrary version of nixpkgs), and `hakyll-flake.pkgs` is the legacyPackages that `hakyll-flakes` uses internally (this should always work). If you want to use one consistent nixpkgs set, you can set `websiteBuildInputs = with hakyll-flakes.${system}.pkgs; [ ... ]`. Alternatively, you can use your own nixpkgs set for these inputs, there's no reason they need to be the same.
 
 # Example
 
@@ -24,8 +23,7 @@ Use this to easily build your hakyll websites using nix flakes.
   outputs = { self, hakyll-flakes, flake-utils, nixpkgs }:
     flake-utils.lib.eachDefaultSystem (
       system:
-      hakyll-flakes.lib.mkAllOutputs {
-        inherit system;
+      hakyll-flakes."${system}".lib.mkAllOutputs {
         name = "my-website";
         src = ./.;
         websiteBuildInputs = with nixpkgs.legacyPackages.${system}; [


### PR DESCRIPTION
#6 broke the flake, which this provides a fix for.
Sorry I didn't test/notice earlier.

This moves the system attribute from the funkction (`hakyll-flakes.lib.mkAllOutputs { inherit system; ...`) to passing it as an attribute (`hakyll-flakes."${system}".lib.mkAllOutputs ...`) to be more consistent with the flake way.
This obviously changes the interface and thereby will have userers perform small manual changes on upgrade.

A fix without changing the interface would be possible as well.
If you choose to reject the pr, please drop 427306bc4efea155630aaed45c519a826fd47480 as well as the project is currently not in a functioning state.