### PR TITLE
change cp to folder-level

### DIFF
--- a/gen.nix
+++ b/gen.nix
@@ -27,8 +27,7 @@ in {
         ${name} build
       '';
       installPhase = ''
-        mkdir -p $out/
-        cp -R _site/* $out/
+        cp -R _site $out
       '';
       dontStrip = true;
     };


### PR DESCRIPTION
This fixes an error where any file starting with a . (dot) was not present in the build output, because it was ignored by the cp command.